### PR TITLE
Updated query execution to prevent SQL injection

### DIFF
--- a/src/python/Query.py
+++ b/src/python/Query.py
@@ -11,7 +11,7 @@ class Query:
 
     def load_configuration(self):
         parser = ConfigParser()
-        parser.read('python/config.ini') # Required file for connection
+        parser.read('./config.ini') # Required file for connection
         params = parser.items('Database') # Required database section
         return {param[0]: param[1] for param in params}
 
@@ -46,24 +46,27 @@ class Query:
         
     def get_team(self, team_name: str) -> None:
         cursor = self.pgdb.cursor()
-        query = f"SELECT * FROM teams WHERE team_name = '{team_name}'"
+        query = "SELECT * FROM teams WHERE team_name = %s"
+        data = (team_name, )
         print(query)
         # query = "SELECT * FROM teams"
-        cursor.execute(query)
+        cursor.execute(query, data)
         for row in cursor:
             print(row)
 
     def get_venue(self, venue_name: str) -> None:
         cursor = self.pgdb.cursor()
-        query = f"SELECT * FROM venues WHERE venue_name = '{venue_name}'"
-        cursor.execute(query)
+        query = "SELECT * FROM venues WHERE venue_name = %s"
+        data = (venue_name, )
+        cursor.execute(query, data)
         for row in cursor:
             print(row)
 
     def get_game(self, game_id: int) -> None:
         cursor = self.pgdb.cursor()
-        query = f"SELECT * FROM games WHERE game_id = {game_id}"
-        cursor.execute(query)
+        query = "SELECT * FROM games WHERE game_id = %s"
+        data = (game_id, )
+        cursor.execute(query, data)
         for row in cursor:
             print(row)
 


### PR DESCRIPTION
Previously user input was directly embedded in the query using an f-string. This exposes the application to SQL injection if a user passes a malicious query. The query execution was updated so psycopg converts the input to a constant and prepares the query to prevent this.

Previous behavior:
As an example, a user could pass the following to the Team query

Team Chiefs' OR 1=1;--

Which results in the following unexpected behavior: ('Texans', 'HOU', 'Houston', 'NRG Stadium', '00143f', 'c41230') ('Packers', 'GB', 'Green Bay', 'Lambeau Field', '204e32', 'ffb612') ('Ravens', 'BAL', 'Baltimore', 'M&T Bank Stadium', '29126f', '000000') ('Commanders', 'WSH', 'Washington', 'FedExField', '5a1414', 'ffb612') ('Broncos', 'DEN', 'Denver', 'Empower Field at Mile High', '0a2343', 'fc4c02') ('49ers', 'SF', 'San Francisco', "Levi's Stadium", 'aa0000', 'b3995d') ('Falcons', 'ATL', 'Atlanta', 'Mercedes-Benz Stadium', 'a71930', '000000') ('Patriots', 'NE', 'New England', 'Gillette Stadium', '002a5c', 'c60c30') ('Bills', 'BUF', 'Buffalo', 'Highmark Stadium', '00338d', 'd50a0a') ('Bears', 'CHI', 'Chicago', 'Soldier Field', '0b1c3a', 'e64100') ('Browns', 'CLE', 'Cleveland', 'Cleveland Browns Stadium', '472a08', 'ff3c00') ('Lions', 'DET', 'Detroit', 'Ford Field', '0076b6', 'bbbbbb') ('Colts', 'IND', 'Indianapolis', 'Lucas Oil Stadium', '003b75', 'ffffff') ('Saints', 'NO', 'New Orleans', 'Caesars Superdome', 'd3bc8d', '000000') ('Jets', 'NYJ', 'New York', 'MetLife Stadium', '115740', 'ffffff') ('Steelers', 'PIT', 'Pittsburgh', 'Acrisure Stadium', '000000', 'ffb612') ('Panthers', 'CAR', 'Carolina', 'Bank of America Stadium', '0085ca', '000000') ('Jaguars', 'JAX', 'Jacksonville', 'EverBank Stadium', '007487', 'd7a22a') ('Rams', 'LAR', 'Los Angeles', 'Los Angeles Memorial Coliseum', '003594', 'ffd100') ('Cowboys', 'DAL', 'Dallas', 'AT&T Stadium', '002a5c', 'b0b7bc') ('Chargers', 'LAC', 'Los Angeles', 'Dignity Health Sports Park', '0080c6', 'ffc20e') ('Chiefs', 'KC', 'Kansas City', 'GEHA Field at Arrowhead Stadium', 'e31837', 'ffb612') ('Eagles', 'PHI', 'Philadelphia', 'Lincoln Financial Field', '06424d', '000000') ('Cardinals', 'ARI', 'Arizona', 'State Farm Stadium', 'a4113e', 'ffffff') ('Buccaneers', 'TB', 'Tampa Bay', 'Raymond James Stadium', 'bd1c36', '3e3a35') ('Raiders', 'LV', 'Las Vegas', 'Allegiant Stadium', '000000', 'a5acaf') ('Giants', 'NYG', 'New York', 'MetLife Stadium', '003c7f', 'c9243f') ('Seahawks', 'SEA', 'Seattle', 'Lumen Field', '002a5c', '69be28') ('Bengals', 'CIN', 'Cincinnati', 'Paycor Stadium', 'fb4f14', '000000') ('Titans', 'TEN', 'Tennessee', 'Nissan Stadium', '4b92db', '002a5c') ('Vikings', 'MIN', 'Minnesota', 'U.S. Bank Stadium', '4f2683', 'ffc62f') ('Dolphins', 'MIA', 'Miami', 'Hard Rock Stadium', '008e97', 'fc4c02')

Updated Response:

Passing Chiefs' OR 1=1;-- now results in no data being returned, which is the correct behavior.